### PR TITLE
Update crop_video.py

### DIFF
--- a/prep/crop_video.py
+++ b/prep/crop_video.py
@@ -90,7 +90,7 @@ def get_clip(input_video_dir, output_video_dir, tsv_fn, bbox_fn, rank, nshard, t
         print(bbox, frames_origin[0].shape, target_size)
         rois = crop_resize(frames_origin, bbox, target_size)
         print(f"Saving ROIs to {output_video}")
-        write_video_ffmpeg(rois, output_video, ffmpeg=ffmpeg)
+        write_video_ffmpeg(rois, output_video.replace(':', '%'), ffmpeg=ffmpeg)
     return
 
 


### PR DESCRIPTION
FIX FILE CREATION

System: Ubuntu

In write_video_ffmpeg method when file name contains : which is given in representation of time example: _Mci9oyb5V2E-00:00:06.000-00:00:06.589.mp4, the output video file doesn't get created

The following command will run but will not be able to create file

cmd = [ffmpeg, "-f", "concat", "-safe", "0", "-i", list_fn, "-q:v", "1", "-r", str(fps), '-y', '-crf', '20', '-pix_fmt', 'yuv420p', target_path] pipe = subprocess.run(cmd, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)

This fix will enable the file creation