### PR TITLE
Updated youtube-dl Download URL

### DIFF
--- a/prep/download.py
+++ b/prep/download.py
@@ -27,7 +27,7 @@ def main():
     os.makedirs(args.dest, exist_ok=True)
     youtube_dl = os.path.join(os.getcwd(), "youtube-dl")
     if not os.path.isfile(youtube_dl):
-        cmd = f"curl -L https://yt-dl.org/downloads/latest/youtube-dl -o {youtube_dl}\nchmod +rx {youtube_dl}"
+        cmd = f"curl -L https://github.com/ytdl-org/ytdl-nightly/releases/latest/download/youtube-dl -o {youtube_dl}\nchmod +rx {youtube_dl}"
         print(cmd)
         subprocess.call(cmd, shell=True)
     if not args.slurm:


### PR DESCRIPTION
Original yt-dl.org website has been blocked, but the latest official version of the youtube-dl can now be downloaded from https://github.com/ytdl-org/ytdl-nightly/releases/latest/